### PR TITLE
allow access from external host for conbu-api-docker

### DIFF
--- a/daemon
+++ b/daemon
@@ -14,9 +14,9 @@ class Zabbix
     @logger.level = Logger::INFO
     @mutex = Mutex.new
     @api = ZabbixApi.connect(
-	    :url => 'http://zabbix.conbu.net/api_jsonrpc.php',
-	    :user => user,
-	    :password => password
+      :url => 'http://zabbix.conbu.net/api_jsonrpc.php',
+      :user => user,
+      :password => password
     )
     @associations = {}
   end
@@ -69,20 +69,16 @@ end
 
 if __FILE__ == $0 then
   config = Pit.get('zabbix',
-		   :require => {
-	  user: 'zabbix username',
-	  password: 'zabbix password',
-  })
+    :require => {
+      user: 'zabbix username',
+      password: 'zabbix password',
+    })
   zabbix = Zabbix.new(config[:user], config[:password])
   zabbix.start
 
   require 'drb/drb'
-  uri = 'druby://localhost:8282'
+  uri = 'druby://0.0.0.0:8282'
   DRb.start_service(uri, zabbix)
   zabbix.stop
   Drb.thread.join
 end
-
-
-
-

--- a/daemon
+++ b/daemon
@@ -7,7 +7,6 @@ require 'logger'
 require 'thread'  # for Mutex
 require 'zabbixapi'
 require 'json'
-require 'drb/acl' # for External access
 
 class Zabbix
   def initialize(user, password)
@@ -79,9 +78,11 @@ if __FILE__ == $0 then
 
   require 'drb/drb'
   uri = 'druby://localhost:8282'
-  acl = ACL.new(%w{allow all})
-  DRb.install_acl(acl)
   DRb.start_service(uri, zabbix)
   zabbix.stop
   Drb.thread.join
 end
+
+
+
+

--- a/daemon
+++ b/daemon
@@ -7,6 +7,7 @@ require 'logger'
 require 'thread'  # for Mutex
 require 'zabbixapi'
 require 'json'
+require 'drb/acl' # for External access
 
 class Zabbix
   def initialize(user, password)
@@ -78,11 +79,9 @@ if __FILE__ == $0 then
 
   require 'drb/drb'
   uri = 'druby://localhost:8282'
+  acl = ACL.new(%w{allow all})
+  DRb.install_acl(acl)
   DRb.start_service(uri, zabbix)
   zabbix.stop
   Drb.thread.join
 end
-
-
-
-


### PR DESCRIPTION
conbu/conbu-api-docker での利用のため、外部ホストからのアクセスを許可する